### PR TITLE
Don't set YUM_OPTS twice when we have a REPO_PROXY

### DIFF
--- a/Makefile.fedora
+++ b/Makefile.fedora
@@ -36,7 +36,7 @@ RPMSIGN_OPTS += --key-id=$(SIGN_KEY)
 endif
 
 ifdef REPO_PROXY
-    YUM_OPTS += "--setopt=proxy=$(REPO_PROXY)"
+    YUM_OPTS += --setopt=proxy=$(REPO_PROXY)
 endif
 
 ifeq ($(shell expr $(subst fc,,$(DIST)) \>= 22),1)

--- a/prepare-chroot-builder
+++ b/prepare-chroot-builder
@@ -24,10 +24,6 @@ else
     YUM_OPTS="$YUM_OPTS -q"
 fi
 
-if [ -n "${REPO_PROXY}" ]; then
-    YUM_OPTS="$YUM_OPTS --setopt=proxy=${REPO_PROXY}"
-fi
-
 INITIAL=
 
 if ! [ -d $DIR/home/user ]; then


### PR DESCRIPTION
prepare-chroot-builder is called through Makefile.fedora (which also
adds the proxy option) using sudo -E, so we end up adding the proxy twice,
once quoted and once not. This leads to errors like:

No package "--setopt=proxy=http://localhost:3128/" available.

When preparing the chroot. Fix it to not do that.