### PR TITLE
Fix missing 'dnf config-manager' when building linux-template-builder (Qubes 3.0)

### DIFF
--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -39,9 +39,9 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
     echo "-> Retreiving core RPM packages..."
     INITIAL_PACKAGES="filesystem setup fedora-release"
     if [ "${DIST#fc}" -ge 22 ]; then
-        INITIAL_PACKAGES="$INITIAL_PACKAGES dnf"
+        INITIAL_PACKAGES="$INITIAL_PACKAGES dnf dnf-plugins-core"
     else
-        INITIAL_PACKAGES="$INITIAL_PACKAGES yum"
+        INITIAL_PACKAGES="$INITIAL_PACKAGES yum yum-utils"
     fi
 
     mkdir -p "${DOWNLOADDIR}"

--- a/template_scripts/distribution.sh
+++ b/template_scripts/distribution.sh
@@ -10,7 +10,7 @@ if [ -n "${REPO_PROXY}" ]; then
     YUM_OPTS="$YUM_OPTS --setopt=proxy=${REPO_PROXY}"
 fi
 
-if [ "${DIST/fc/}" -ge 21 ]; then
+if [ "${DIST/fc/}" -ge 22 ]; then
     YUM=dnf
 else
     YUM=yum


### PR DESCRIPTION
Building **linux-template-builder** for Qubes 3.0 is currently broken, because changing repositories is handled via  _'dnf config-manager'_ plugin and not _yum-config-manager_. However **yum-utils** (offers yum-config-manager) is not installed:

```
Building template: fc21
-> Preparing instalation of fc21 template...
-> Initializing empty image...
-> Creating filesystem...
-> Initializing RPM database...
-> Retreiving core RPM packages...

Yum-utils package has been deprecated, use dnf instead.
See 'man yum2dnf' for more information.
...
```
Then only dnf is installed, but even then it's missing the config-manager plugin (package **dnf-plugins-core**).

In the end, this results in error:
```
...
No such command: config-manager. Please use /bin/dnf --help
Makefile:47: recipe for target 'rootimg-build' failed
make[1]: *** [rootimg-build] Error 1
```

FIX: Force installation of yum-utils and dnf-plugins-core (although I'm not sure if the latter is needed because it should be installed with newer templates automatically?). Then refer to right config manager in distribution.sh

Signed-off-by: WetwareLabs <marcus@wetwa.re>