### PR TITLE
Support for defining DNF mirrors in builder.conf: typically local mirrors

### DIFF
--- a/Makefile.fedora
+++ b/Makefile.fedora
@@ -39,9 +39,9 @@ ifdef REPO_PROXY
     YUM_OPTS += --setopt=proxy=$(REPO_PROXY)
 endif
 
-ifdef FEDORA_MIRRORS
-    YUM_OPTS += --setopt=fedora.baseurl=$(FEDORA_MIRRORS)/fedora/linux/releases/$(subst fc,,$(DIST))/Everything/x86_64/os/
-    YUM_OPTS += --setopt=updates.baseurl=$(FEDORA_MIRRORS)/fedora/linux/updates/$(subst fc,,$(DIST))/x86_64/
+ifdef FEDORA_MIRROR
+    YUM_OPTS += --setopt=fedora.baseurl=$(FEDORA_MIRROR)/fedora/linux/releases/$(subst fc,,$(DIST))/Everything/x86_64/os/
+    YUM_OPTS += --setopt=updates.baseurl=$(FEDORA_MIRROR)/fedora/linux/updates/$(subst fc,,$(DIST))/x86_64/
 endif
 
 ifeq ($(shell expr $(subst fc,,$(DIST)) \>= 22),1)

--- a/Makefile.fedora
+++ b/Makefile.fedora
@@ -39,6 +39,11 @@ ifdef REPO_PROXY
     YUM_OPTS += --setopt=proxy=$(REPO_PROXY)
 endif
 
+ifdef REPO_BASEURL_PREFIX
+    YUM_OPTS += --setopt=fedora.baseurl=$(REPO_BASEURL_PREFIX)/fedora/linux/releases/$(subst fc,,$(DIST))/Everything/x86_64/os/
+    YUM_OPTS += --setopt=updates.baseurl=$(REPO_BASEURL_PREFIX)/fedora/linux/updates/$(subst fc,,$(DIST))/x86_64/
+endif
+
 ifeq ($(shell expr $(subst fc,,$(DIST)) \>= 22),1)
 	YUM := dnf
 	YUM_BUILDDEP := dnf builddep --allowerasing --best

--- a/Makefile.fedora
+++ b/Makefile.fedora
@@ -39,9 +39,9 @@ ifdef REPO_PROXY
     YUM_OPTS += --setopt=proxy=$(REPO_PROXY)
 endif
 
-ifdef REPO_BASEURL_PREFIX
-    YUM_OPTS += --setopt=fedora.baseurl=$(REPO_BASEURL_PREFIX)/fedora/linux/releases/$(subst fc,,$(DIST))/Everything/x86_64/os/
-    YUM_OPTS += --setopt=updates.baseurl=$(REPO_BASEURL_PREFIX)/fedora/linux/updates/$(subst fc,,$(DIST))/x86_64/
+ifdef FEDORA_MIRRORS
+    YUM_OPTS += --setopt=fedora.baseurl=$(FEDORA_MIRRORS)/fedora/linux/releases/$(subst fc,,$(DIST))/Everything/x86_64/os/
+    YUM_OPTS += --setopt=updates.baseurl=$(FEDORA_MIRRORS)/fedora/linux/updates/$(subst fc,,$(DIST))/x86_64/
 endif
 
 ifeq ($(shell expr $(subst fc,,$(DIST)) \>= 22),1)

--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -56,9 +56,20 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
 
     mkdir -p "${DOWNLOADDIR}"
     yumconf=$(mktemp)
-    sed -e "s/\\\$releasever/${DIST#fc}/g" \
-        < "${PLUGIN_DIR}"/yum-bootstrap.conf \
-        > "$yumconf"
+
+    # For defined mirroris in builder.conf we need to delete the metalink option
+    # in the repo file because baseurl seems to not override the metalink
+    if [ "x${REPO_BASEURL_PREFIX}" != "x" ]; then
+        sed -e "s/\\\$releasever/${DIST#fc}/g" \
+            -e "/metalink/d" \
+            < "${PLUGIN_DIR}"/yum-bootstrap.conf \
+            > "$yumconf"
+    else
+        sed -e "s/\\\$releasever/${DIST#fc}/g" \
+            < "${PLUGIN_DIR}"/yum-bootstrap.conf \
+            > "$yumconf"
+    fi
+
     $YUM -c "$yumconf" -y \
         --installroot="${INSTALLDIR}" \
         ${INITIAL_PACKAGES}
@@ -92,6 +103,12 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
     for f in null urandom zero random console; do
         cp -a /dev/$f $INSTALLDIR/dev/
     done
+
+    # TODO: check if there is a way to force baseurl to override metalink
+    if [ "x$REPO_BASEURL_PREFIX" != "x" ]; then
+        sed -i "/metalink/d" "${INSTALLDIR}/etc/yum.repos.d/fedora.repo" "${INSTALLDIR}/etc/yum.repos.d/fedora-updates.repo"
+        sed -i "s/#baseurl/baseurl/g" "${INSTALLDIR}/etc/yum.repos.d/fedora.repo" "${INSTALLDIR}/etc/yum.repos.d/fedora-updates.repo"
+    fi
 
     touch "${INSTALLDIR}/tmp/.prepared_base"
 fi

--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -59,7 +59,7 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
 
     # For defined mirroris in builder.conf we need to delete the metalink option
     # in the repo file because baseurl seems to not override the metalink
-    if [ "x${FEDORA_MIRRORS}" != "x" ]; then
+    if [ "x${FEDORA_MIRROR}" != "x" ]; then
         sed -e "s/\\\$releasever/${DIST#fc}/g" \
             -e "s/^metalink/#metalink/g" \
             < "${PLUGIN_DIR}"/yum-bootstrap.conf \
@@ -105,7 +105,7 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
     done
 
     # TODO: check if there is a way to force baseurl to override metalink
-    if [ "x$FEDORA_MIRRORS" != "x" ]; then
+    if [ "x$FEDORA_MIRROR" != "x" ]; then
         sed -i "s/^metalink/#metalink/g" "${INSTALLDIR}/etc/yum.repos.d/fedora.repo" "${INSTALLDIR}/etc/yum.repos.d/fedora-updates.repo"
         sed -i "s/#baseurl/baseurl/g" "${INSTALLDIR}/etc/yum.repos.d/fedora.repo" "${INSTALLDIR}/etc/yum.repos.d/fedora-updates.repo"
     fi

--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -61,7 +61,7 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
     # in the repo file because baseurl seems to not override the metalink
     if [ "x${FEDORA_MIRRORS}" != "x" ]; then
         sed -e "s/\\\$releasever/${DIST#fc}/g" \
-            -e "/metalink/d" \
+            -e "s/^metalink/#metalink/g" \
             < "${PLUGIN_DIR}"/yum-bootstrap.conf \
             > "$yumconf"
     else
@@ -106,7 +106,7 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
 
     # TODO: check if there is a way to force baseurl to override metalink
     if [ "x$FEDORA_MIRRORS" != "x" ]; then
-        sed -i "/metalink/d" "${INSTALLDIR}/etc/yum.repos.d/fedora.repo" "${INSTALLDIR}/etc/yum.repos.d/fedora-updates.repo"
+        sed -i "s/^metalink/#metalink/g" "${INSTALLDIR}/etc/yum.repos.d/fedora.repo" "${INSTALLDIR}/etc/yum.repos.d/fedora-updates.repo"
         sed -i "s/#baseurl/baseurl/g" "${INSTALLDIR}/etc/yum.repos.d/fedora.repo" "${INSTALLDIR}/etc/yum.repos.d/fedora-updates.repo"
     fi
 

--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -59,7 +59,7 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
 
     # For defined mirroris in builder.conf we need to delete the metalink option
     # in the repo file because baseurl seems to not override the metalink
-    if [ "x${REPO_BASEURL_PREFIX}" != "x" ]; then
+    if [ "x${FEDORA_MIRRORS}" != "x" ]; then
         sed -e "s/\\\$releasever/${DIST#fc}/g" \
             -e "/metalink/d" \
             < "${PLUGIN_DIR}"/yum-bootstrap.conf \
@@ -105,7 +105,7 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
     done
 
     # TODO: check if there is a way to force baseurl to override metalink
-    if [ "x$REPO_BASEURL_PREFIX" != "x" ]; then
+    if [ "x$FEDORA_MIRRORS" != "x" ]; then
         sed -i "/metalink/d" "${INSTALLDIR}/etc/yum.repos.d/fedora.repo" "${INSTALLDIR}/etc/yum.repos.d/fedora-updates.repo"
         sed -i "s/#baseurl/baseurl/g" "${INSTALLDIR}/etc/yum.repos.d/fedora.repo" "${INSTALLDIR}/etc/yum.repos.d/fedora-updates.repo"
     fi

--- a/template_scripts/distribution.sh
+++ b/template_scripts/distribution.sh
@@ -10,9 +10,9 @@ if [ -n "${REPO_PROXY}" ]; then
     YUM_OPTS="$YUM_OPTS --setopt=proxy=${REPO_PROXY}"
 fi
 
-if [ -n "${FEDORA_MIRRORS}" ]; then
-    YUM_OPTS="$YUM_OPTS --setopt=fedora.baseurl=${FEDORA_MIRRORS}/fedora/linux/releases/${DIST/fc/}/Everything/x86_64/os/"
-    YUM_OPTS="$YUM_OPTS --setopt=updates.baseurl=${FEDORA_MIRRORS}/fedora/linux/updates/${DIST/fc/}/x86_64/"
+if [ -n "${FEDORA_MIRROR}" ]; then
+    YUM_OPTS="$YUM_OPTS --setopt=fedora.baseurl=${FEDORA_MIRROR}/fedora/linux/releases/${DIST/fc/}/Everything/x86_64/os/"
+    YUM_OPTS="$YUM_OPTS --setopt=updates.baseurl=${FEDORA_MIRROR}/fedora/linux/updates/${DIST/fc/}/x86_64/"
 fi
 
 if [ "${DIST/fc/}" -ge 22 ]; then

--- a/template_scripts/distribution.sh
+++ b/template_scripts/distribution.sh
@@ -10,6 +10,11 @@ if [ -n "${REPO_PROXY}" ]; then
     YUM_OPTS="$YUM_OPTS --setopt=proxy=${REPO_PROXY}"
 fi
 
+if [ -n "${REPO_BASEURL_PREFIX}" ]; then
+    YUM_OPTS="$YUM_OPTS --setopt=fedora.baseurl=${REPO_BASEURL_PREFIX}/fedora/linux/releases/${DIST/fc/}/Everything/x86_64/os/"
+    YUM_OPTS="$YUM_OPTS --setopt=updates.baseurl=${REPO_BASEURL_PREFIX}/fedora/linux/updates/${DIST/fc/}/x86_64/"
+fi
+
 if [ "${DIST/fc/}" -ge 22 ]; then
     YUM=dnf
 else

--- a/template_scripts/distribution.sh
+++ b/template_scripts/distribution.sh
@@ -10,9 +10,9 @@ if [ -n "${REPO_PROXY}" ]; then
     YUM_OPTS="$YUM_OPTS --setopt=proxy=${REPO_PROXY}"
 fi
 
-if [ -n "${REPO_BASEURL_PREFIX}" ]; then
-    YUM_OPTS="$YUM_OPTS --setopt=fedora.baseurl=${REPO_BASEURL_PREFIX}/fedora/linux/releases/${DIST/fc/}/Everything/x86_64/os/"
-    YUM_OPTS="$YUM_OPTS --setopt=updates.baseurl=${REPO_BASEURL_PREFIX}/fedora/linux/updates/${DIST/fc/}/x86_64/"
+if [ -n "${FEDORA_MIRRORS}" ]; then
+    YUM_OPTS="$YUM_OPTS --setopt=fedora.baseurl=${FEDORA_MIRRORS}/fedora/linux/releases/${DIST/fc/}/Everything/x86_64/os/"
+    YUM_OPTS="$YUM_OPTS --setopt=updates.baseurl=${FEDORA_MIRRORS}/fedora/linux/updates/${DIST/fc/}/x86_64/"
 fi
 
 if [ "${DIST/fc/}" -ge 22 ]; then


### PR DESCRIPTION
Here is what I propose as an alternative of using REPO_PROXY: we need to define in the builder.conf the variable REPO_BASEURL_PREFIX. Then, the main and update repos are defined as:

$(REPO_BASEURL_PREFIX)/fedora/linux/releases/$(subst fc,,$(DIST))/Everything and $(REPO_BASEURL_PREFIX)/fedora/linux/updates/$(subst fc,,$(DIST))/x86_64/.

So for example one can define REPO_BASEURL_PREFIX=http://mylocalmirror/pub following the default structure of Fedora mirrors.

It uses "baseurl" but the problem is that it does not override the metalink option and it seems there is not any cmd line option to delete the option. In consequence, we have to remove it manually when constructing the chroot env.