### PR TITLE
Add iptables package to fedora-26-minimal

### DIFF
--- a/template_scripts/packages_fc26_minimal.list
+++ b/template_scripts/packages_fc26_minimal.list
@@ -2,6 +2,7 @@ xterm
 tar
 haveged
 sudo
+iptables
 --exclude=kdegames
 --exclude=firstboot
 --exclude=xorg-x11-drv-nouveau


### PR DESCRIPTION
Apparently, this is not included by default anymore, which breaks fedora-26-minimal for NetVM/ProxyVM use.