### PR TITLE
Fix using FEDORA_MIRROR for dist-prepare-chroot

### DIFF
--- a/Makefile.fedora
+++ b/Makefile.fedora
@@ -40,8 +40,8 @@ ifdef REPO_PROXY
 endif
 
 ifdef FEDORA_MIRROR
-    YUM_OPTS += --setopt=fedora.baseurl=$(FEDORA_MIRROR)/fedora/linux/releases/$(subst fc,,$(DIST))/Everything/x86_64/os/
-    YUM_OPTS += --setopt=updates.baseurl=$(FEDORA_MIRROR)/fedora/linux/updates/$(subst fc,,$(DIST))/x86_64/
+    YUM_OPTS += --setopt=fedora.baseurl=$(patsubst %/,%,$(FEDORA_MIRROR))/releases/$(subst fc,,$(DIST))/Everything/x86_64/os/
+    YUM_OPTS += --setopt=updates.baseurl=$(patsubst %/,%,$(FEDORA_MIRROR))/updates/$(subst fc,,$(DIST))/x86_64/
 endif
 
 ifeq ($(shell expr $(subst fc,,$(DIST)) \>= 22),1)

--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -58,8 +58,17 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
     # For defined mirroris in builder.conf we need to delete the metalink option
     # in the repo file because baseurl seems to not override the metalink
     if [ "x${FEDORA_MIRROR}" != "x" ]; then
-        sed -e "s/\\\$releasever/${DIST#fc}/g" \
-            -e "s/^metalink/#metalink/g" \
+        awk '
+        BEGIN {
+            mirror=ARGV[1];     delete ARGV[1];
+            releasever=ARGV[2]; delete ARGV[2];
+        }
+        {
+            gsub("^metalink", "#metalink");
+            gsub("^#baseurl=.*/(linux|fedora)/", "baseurl=" mirror "/");
+            gsub("\\$releasever", releasever);
+            print;
+        }' "${FEDORA_MIRROR%/}" "${DIST#fc}" \
             < "${PLUGIN_DIR}"/yum-bootstrap.conf \
             > "$yumconf"
     else

--- a/template_scripts/distribution.sh
+++ b/template_scripts/distribution.sh
@@ -11,8 +11,8 @@ if [ -n "${REPO_PROXY}" ]; then
 fi
 
 if [ -n "${FEDORA_MIRROR}" ]; then
-    YUM_OPTS="$YUM_OPTS --setopt=fedora.baseurl=${FEDORA_MIRROR}/fedora/linux/releases/${DIST/fc/}/Everything/x86_64/os/"
-    YUM_OPTS="$YUM_OPTS --setopt=updates.baseurl=${FEDORA_MIRROR}/fedora/linux/updates/${DIST/fc/}/x86_64/"
+    YUM_OPTS="$YUM_OPTS --setopt=fedora.baseurl=${FEDORA_MIRROR%/}/releases/${DIST/fc/}/Everything/x86_64/os/"
+    YUM_OPTS="$YUM_OPTS --setopt=updates.baseurl=${FEDORA_MIRROR%/}/updates/${DIST/fc/}/x86_64/"
 fi
 
 if [ "${DIST/fc/}" -ge 22 ]; then


### PR DESCRIPTION
Previously, if your builder VM was firewalled off to all but a few
hosts and did not already have a chroot for the dist you're building,
then initial chroot bootstrapping would slowly try one mirror after
another regardless of FEDORA_MIRROR being set.

This patch also changes the required format of FEDORA_MIRROR to
no longer hard-code `/fedora/linux/releases/`, since not all mirrors
conform to that layout. For a list of mirrors and paths, see:
 - https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-25&arch=x86_64

Example of new valid value:
 - `FEDORA_MIRROR=https://mirrors.kernel.org/fedora/`