### PR TITLE
Fix broken dependency due to yum-utils in Fedora26/27

### DIFF
--- a/template_scripts/packages_fc26.list
+++ b/template_scripts/packages_fc26.list
@@ -26,4 +26,5 @@ mate-notification-daemon
 sudo
 xorg-x11-fonts-100dpi
 xorg-x11-fonts-Type1
-yum-utils
+dnf-utils
+--exclude=yum-utils

--- a/template_scripts/packages_fc26_minimal.list
+++ b/template_scripts/packages_fc26_minimal.list
@@ -7,3 +7,4 @@ sudo
 --exclude=xorg-x11-drv-nouveau
 --exclude=firewall-config,firewalld
 --exclude=gnome-boxes
+--exclude=yum-utils

--- a/template_scripts/packages_fc27.list
+++ b/template_scripts/packages_fc27.list
@@ -33,3 +33,4 @@ sudo
 xorg-x11-fonts-100dpi
 xorg-x11-fonts-Type1
 dnf-utils
+--exclude=yum-utils

--- a/template_scripts/packages_fc27_minimal.list
+++ b/template_scripts/packages_fc27_minimal.list
@@ -7,3 +7,4 @@ sudo
 --exclude=xorg-x11-drv-nouveau
 --exclude=firewall-config,firewalld
 --exclude=gnome-boxes
+--exclude=yum-utils


### PR DESCRIPTION
I excluded yum-utils from template packages list. The built Fedora templates does not complain about broken dependencies due to yum-utils.

This is tracked by QubesOS/qubes-issues#3426