### PR TITLE
fedora-26: replace @workstation-product-environment by @gnome-desktop

### DIFF
--- a/template_scripts/packages_fc26.list
+++ b/template_scripts/packages_fc26.list
@@ -1,5 +1,5 @@
 --setopt=strict=false
-@workstation-product-environment
+@gnome-desktop
 vim-enhanced
 gnupg
 xterm
@@ -26,5 +26,6 @@ mate-notification-daemon
 sudo
 xorg-x11-fonts-100dpi
 xorg-x11-fonts-Type1
+dnf
 dnf-utils
 --exclude=yum-utils


### PR DESCRIPTION
I obtained a template of size ~990mo. Like I did for fc27 the workspace group installs so much useless things. Need to fix dnf also for fc27. I tested it briefly on 3.2 and things seem fine.