### PR TITLE
Fix errors from unnecessary query of spec:

### DIFF
--- a/scripts/query-spec
+++ b/scripts/query-spec
@@ -14,6 +14,8 @@ if [ $# -lt 2 ]; then
     exit 1
 fi
 
+[[ "x$(basename ${1}.in)" == "x.in" ]] && exit 0
+
 if [ -r "${1}.in" ]; then
     #rpm -q $RPM_QUERY_DEFINES --qf "$2" --specfile <(`dirname $0`/generate-spec "${1}.in" /dev/stdout) 2>/dev/null
     # need to create a file due to a bug in process substitution (e.g. artwork package)


### PR DESCRIPTION
When the current package does not need to be built on the current
DIST, no information about the spec file is provided from RPM_SPEC_FILES.
In that case, the query spec try to get information from empty name file.